### PR TITLE
Remove deprecated curl_close() call

### DIFF
--- a/TVMaze/TVMaze.php
+++ b/TVMaze/TVMaze.php
@@ -380,7 +380,6 @@ class TVMaze {
 		curl_setopt($ch, CURLOPT_URL, $url);
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
 		$result = curl_exec($ch);
-		curl_close($ch);
 
 		$response = json_decode($result, TRUE);
 		if (is_array($response) && count($response) > 0 && (!isset($response['status']) || $response['status'] != '404')) {


### PR DESCRIPTION
DEPRECATED  Function curl_close() is deprecated since 8.5, as it has no effect since PHP 8.0